### PR TITLE
ea-server: config model with query params

### DIFF
--- a/ea_server/api/__init__.py
+++ b/ea_server/api/__init__.py
@@ -12,6 +12,6 @@ def create_app(config_class=Config):
     from ea_server.api import routes
 
     # Register Blueprints
-    app.register_blueprint(routes.api_blueprint)
+    app.register_blueprint(routes.api_v1_blueprint)
 
     return app

--- a/ea_server/api/routes.py
+++ b/ea_server/api/routes.py
@@ -1,12 +1,7 @@
-import functools
-from flask import Blueprint, jsonify, request
-from ea_server.api.utils import transform
+from flask import Blueprint, request
+from ea_server.api.utils.parser import parse_result
 from ea_server.engine.ea import EA
-from utils.ea_builder import EABuilder
-from ea_server.engine.cx import Crossovers
-from ea_server.engine.mut import Mutates
-from ea_server.engine.sel import Selection
-from werkzeug.datastructures import MultiDict
+from ea_server.api.utils.ea_builder import EABuilder
 
 api_v1_blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
 
@@ -23,7 +18,7 @@ def evaluate():
 
     result, log = ea.eval_model()
     best_individual = EA.get_best_individual(result)
-    object_result = transform(best_individual,data)
+    object_result = parse_result(best_individual, data)
     print('best individual: ', object_result)
 
     return object_result

--- a/ea_server/api/routes.py
+++ b/ea_server/api/routes.py
@@ -2,22 +2,24 @@ import functools
 from flask import Blueprint, jsonify, request
 from ea_server.api.utils import transform
 from ea_server.engine.ea import EA
+from utils.ea_builder import EABuilder
 from ea_server.engine.cx import Crossovers
 from ea_server.engine.mut import Mutates
 from ea_server.engine.sel import Selection
-import json
-api_blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
+from werkzeug.datastructures import MultiDict
+
+api_v1_blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
 
 
-@api_blueprint.route('/ea', methods=['GET'])
+@api_v1_blueprint.route('/ea', methods=['GET'])
 def evaluate():
     data = request.get_json()
+    args = request.args
 
-    ea = EA(data) \
-        .set_pop_size(100) \
-        .set_crossover(Crossovers.SINGLE_POINT) \
-        .set_mutate(Mutates.SHUFFLE, indpb=0.05) \
-        .set_selection(Selection.TOURNAMENT, tournsize=3) \
+    ea = EABuilder() \
+        .with_data(data) \
+        .with_args(args) \
+        .build()
 
     result, log = ea.eval_model()
     best_individual = EA.get_best_individual(result)

--- a/ea_server/api/utils/ea_builder.py
+++ b/ea_server/api/utils/ea_builder.py
@@ -1,0 +1,53 @@
+from ea_server.engine.ea import EA
+from werkzeug.datastructures import MultiDict
+
+
+class EABuilder:
+    def __init__(self):
+        self.data = {}
+        self.args = MultiDict[str, str]()
+        pass
+
+    def with_data(self, data):
+        self.data = data
+        return self
+
+    def with_args(self, args: MultiDict[str, str]):
+        self.args = args
+        return self
+
+    def build(self):
+        self.ea = EA(self.data)
+        self.set_args()
+        return self.ea
+
+    def set_args(self):
+
+        if num_orders := self.args.get('num_orders', type=int):
+            self.ea.set_num_orders(num_orders)
+
+        if num_drivers := self.args.get('num_drivers', type=int):
+            self.ea.set_num_drivers(num_drivers)
+
+        if crossover := self.args.get('crossover'):
+            self.ea.set_crossover(crossover)
+
+        if mutate := self.args.get('mutate'):
+            # TODO: deal with selection kwargs and add validation
+            self.ea.set_mutate(mutate)
+
+        if selection := self.args.get('selection'):
+            # TODO: deal with selection kwargs and add validation
+            self.ea.set_selection(selection)
+
+        if pop_size := self.args.get('pop_size', type=int):
+            self.ea.set_pop_size(pop_size)
+
+        if cxpb := self.args.get('cxpb', type=float):
+            self.ea.set_cxpb(cxpb)
+
+        if mutpd := self.args.get('mutpd', type=float):
+            self.ea.set_mutpd(mutpd)
+
+        if num_generations := self.args.get('num_generations', type=int):
+            self.ea.set_num_generations(num_generations)

--- a/ea_server/api/utils/ea_builder.py
+++ b/ea_server/api/utils/ea_builder.py
@@ -17,12 +17,12 @@ class EABuilder:
         return self
 
     def build(self):
+        self.validate_data()
         self.ea = EA(self.data)
         self.set_args()
         return self.ea
 
     def set_args(self):
-
         if num_orders := self.args.get('num_orders', type=int):
             self.ea.set_num_orders(num_orders)
 
@@ -51,3 +51,8 @@ class EABuilder:
 
         if num_generations := self.args.get('num_generations', type=int):
             self.ea.set_num_generations(num_generations)
+
+    def validate_data(self):
+        for key in EA.REQUIRED_DATA_KEYS:
+            if self.data.get(key) is None:
+                raise ValueError(f'Missing {key} in data')

--- a/ea_server/api/utils/ea_builder.py
+++ b/ea_server/api/utils/ea_builder.py
@@ -30,15 +30,16 @@ class EABuilder:
             self.ea.set_num_drivers(num_drivers)
 
         if crossover := self.args.get('crossover'):
-            self.ea.set_crossover(crossover)
+            kwargs = self.data.get('crossover_kwargs', {})
+            self.ea.set_crossover(crossover, **kwargs)
 
         if mutate := self.args.get('mutate'):
-            # TODO: deal with selection kwargs and add validation
-            self.ea.set_mutate(mutate)
+            kwargs = self.data.get('mutate_kwargs', {})
+            self.ea.set_mutate(mutate, **kwargs)
 
         if selection := self.args.get('selection'):
-            # TODO: deal with selection kwargs and add validation
-            self.ea.set_selection(selection)
+            kwargs = self.data.get('selection_kwargs', {})
+            self.ea.set_selection(selection, **kwargs)
 
         if pop_size := self.args.get('pop_size', type=int):
             self.ea.set_pop_size(pop_size)

--- a/ea_server/api/utils/parser.py
+++ b/ea_server/api/utils/parser.py
@@ -2,7 +2,22 @@ import math
 from operator import itemgetter
 
 
-def transform(result, data):
+def parse_result(result, data):
+    """
+    Object Structure
+    { 
+        "driver_id1":[orderId , orderId,...],
+        "driver_id2":[orderId , orderId,...],
+        "driver_id3":[orderId , orderId,...]
+    }
+    The object with current data:
+    {
+        "11": ["4", "1"],
+        "12": ["5", "6"],
+        "13": ["3", "2"]
+    }    
+    """
+
     result_as_dict = {driver["id"]:[] for driver in data["drivers"]}
 
     for order_index, number in enumerate(result):
@@ -17,24 +32,3 @@ def transform(result, data):
         result_as_dict[driver] = [i[0] for i in result_as_dict[driver]]
 
     return result_as_dict
-
-# Object Structure
-# { "driver_id1":[orderId , orderId,...],
-#   "driver_id2":[orderId , orderId,...],
-#   "driver_id3":[orderId , orderId,...]
-# }
-# The object with current data:
-# {
-#  "11": [
-#    "4",
-#    "1"
-#  ],
-#  "12": [
-#    "5",
-#    "6"
-#  ],
-#  "13": [
-#    "3",
-#    "2"
-#  ]
-# }

--- a/ea_server/api/utils/parser.py
+++ b/ea_server/api/utils/parser.py
@@ -27,7 +27,6 @@ def parse_result(result, data):
         result_as_dict[driver_id].append(item)
 
     for driver in result_as_dict:
-        print(result_as_dict[driver])
         result_as_dict[driver] = sorted(result_as_dict[driver], key=itemgetter(1))
         result_as_dict[driver] = [i[0] for i in result_as_dict[driver]]
 

--- a/ea_server/engine/cx.py
+++ b/ea_server/engine/cx.py
@@ -1,8 +1,18 @@
+from aifc import Error
+from nis import match
+from unittest import case
 from deap import tools
 
 class Crossovers():
     SINGLE_POINT = tools.cxOnePoint
 
     @classmethod
-    def get_default(cls):
+    def get_default(cls) -> function:
         return cls.SINGLE_POINT
+
+    @classmethod
+    def get(cls, type: str) -> function:
+        if type == 'single-point':
+            return cls.SINGLE_POINT
+        
+        raise ValueError('Invalid crossover name')

--- a/ea_server/engine/cx.py
+++ b/ea_server/engine/cx.py
@@ -1,18 +1,44 @@
-from aifc import Error
-from nis import match
-from unittest import case
+from enum import Enum
+from click import MissingParameter
 from deap import tools
 
-class Crossovers():
-    SINGLE_POINT = tools.cxOnePoint
+
+class CrossoverTypes(Enum):
+    SINGLE_POINT = 'single_point'
+
+
+class Crossover():
+
+    FUNCTIONS = {
+        CrossoverTypes.SINGLE_POINT: tools.cxOnePoint
+    }
+
+    KWARGS = {
+        CrossoverTypes.SINGLE_POINT: []
+    }
 
     @classmethod
-    def get_default(cls) -> function:
-        return cls.SINGLE_POINT
+    def default(cls):
+        return (cls.FUNCTIONS[CrossoverTypes.SINGLE_POINT], {})
 
     @classmethod
-    def get(cls, type: str) -> function:
-        if type == 'single-point':
-            return cls.SINGLE_POINT
-        
-        raise ValueError('Invalid crossover name')
+    def get(cls, type: str):
+        return cls.FUNCTIONS[CrossoverTypes(type)]
+
+    @classmethod
+    def get_kwargs(cls, type: str):
+        return cls.KWARGS[CrossoverTypes(type)]
+
+    @classmethod
+    def get_types(cls):
+        return [e.value for e in CrossoverTypes]
+
+    @classmethod
+    def validate(cls, type: str, **kwargs):
+        if keys := cls.get_kwargs(type):
+            missing = [key for key in keys if key not in kwargs]
+            if len(missing) > 0:
+                raise MissingParameter(
+                    f'Missing keys {missing} for {type} (in {cls.__name__})')
+
+        return True

--- a/ea_server/engine/ea.py
+++ b/ea_server/engine/ea.py
@@ -7,6 +7,7 @@ from ea_server.engine.cx import Crossovers
 from ea_server.engine.mut import Mutates
 from ea_server.engine.sel import Selection
 
+
 class EA:
 
     @staticmethod
@@ -42,41 +43,41 @@ class EA:
             "select", self.selection_type, **self.selection_kwargs)
         self.__pop = self.__toolbox.population(n=self.pop_size)
 
-    def set_num_orders(self, num_orders):
+    def set_num_orders(self, num_orders: int):
         self.num_orders = num_orders
         return self
 
-    def set_num_drivers(self, num_drivers):
+    def set_num_drivers(self, num_drivers: int):
         self.num_drivers = num_drivers
         return self
 
-    def set_crossover(self, crossover_type):
-        self.crossover_type = crossover_type
+    def set_crossover(self, crossover_name: str):
+        self.crossover_type = Crossovers.get(crossover_name)
         return self
 
-    def set_mutate(self, mutate_type, **kwargs):
-        self.mutate_type = mutate_type
+    def set_mutate(self, mutate_name: str, **kwargs):
+        self.mutate_type = Mutates.get(mutate_name)
         self.mutate_kwargs = kwargs
         return self
 
-    def set_selection(self, selection_type, **kwargs):
-        self.selection_type = selection_type
+    def set_selection(self, selection_name: str, **kwargs):
+        self.selection_type = Selection.get(selection_name)
         self.selection_kwargs = kwargs
         return self
 
-    def set_pop_size(self, pop_size):
+    def set_pop_size(self, pop_size: int):
         self.pop_size = pop_size
         return self
 
-    def set_cxpb(self, cxpb):
+    def set_cxpb(self, cxpb: float):
         self.cxpb = cxpb
         return self
 
-    def set_mutpd(self, mutpd):
+    def set_mutpd(self, mutpd: float):
         self.mutpd = mutpd
         return self
 
-    def set_num_generations(self, num_generations):
+    def set_num_generations(self, num_generations: int):
         self.num_generations = num_generations
         return self
 
@@ -121,11 +122,10 @@ class EA:
 
         # need to think on the penalty weight
         fitness = sum(drivers_total_distance) \
-             + self.weight_penalty(drivers_total_weight) \
-             + self.distance_penalty(drivers_total_distance)
+            + self.weight_penalty(drivers_total_weight) \
+            + self.distance_penalty(drivers_total_distance)
 
         return (fitness,)
-
 
     def weight_penalty(self, drivers_total_weight):
         penalty = 0

--- a/ea_server/engine/ea.py
+++ b/ea_server/engine/ea.py
@@ -3,8 +3,8 @@ import math
 import random
 from deap import algorithms, base, creator, tools
 from operator import itemgetter
-from ea_server.engine.cx import Crossovers
-from ea_server.engine.mut import Mutates
+from ea_server.engine.cx import Crossover
+from ea_server.engine.mut import Mutate
 from ea_server.engine.sel import Selection
 
 
@@ -23,9 +23,9 @@ class EA:
         self.mutpd = 0.2
         self.num_drivers = len(data["drivers"])
         self.num_orders = len(data["orders"])
-        self.crossover_type = Crossovers.get_default()
-        self.mutate_type, self.mutate_kwargs = Mutates.get_default()
-        self.selection_type, self.selection_kwargs = Selection.get_default()
+        self.crossover_type, self.crossover_kwargs = Crossover.default()
+        self.mutate_type, self.mutate_kwargs = Mutate.default()
+        self.selection_type, self.selection_kwargs = Selection.default()
 
     def build(self):
         creator.create("FitnessMin", base.Fitness, weights=(-1.0,))
@@ -37,7 +37,7 @@ class EA:
         self.__toolbox.register(
             "population", tools.initRepeat, list, self.__toolbox.individual)
         self.__toolbox.register("evaluate", self.__evaluation)
-        self.__toolbox.register("mate", self.crossover_type)
+        self.__toolbox.register("mate", self.crossover_type , **self.crossover_kwargs)
         self.__toolbox.register(
             "mutate", self.mutate_type, **self.mutate_kwargs)
         self.__toolbox.register(
@@ -52,12 +52,13 @@ class EA:
         self.num_drivers = num_drivers
         return self
 
-    def set_crossover(self, crossover_name: str):
-        self.crossover_type = Crossovers.get(crossover_name)
+    def set_crossover(self, crossover_name: str, **kwargs):
+        self.crossover_type = Crossover.get(crossover_name)
+        self.crossover_kwargs = kwargs
         return self
 
     def set_mutate(self, mutate_name: str, **kwargs):
-        self.mutate_type = Mutates.get(mutate_name)
+        self.mutate_type = Mutate.get(mutate_name)
         self.mutate_kwargs = kwargs
         return self
 

--- a/ea_server/engine/ea.py
+++ b/ea_server/engine/ea.py
@@ -9,6 +9,7 @@ from ea_server.engine.sel import Selection
 
 
 class EA:
+    REQUIRED_DATA_KEYS = ['drivers', 'orders']
 
     @staticmethod
     def get_best_individual(result, top=1):

--- a/ea_server/engine/mut.py
+++ b/ea_server/engine/mut.py
@@ -1,8 +1,16 @@
 from deap import tools
 
+
 class Mutates():
     SHUFFLE = tools.mutShuffleIndexes
 
     @classmethod
     def get_default(cls):
         return cls.SHUFFLE, {"indpb": 0.05}
+
+    @classmethod
+    def get(cls, type: str):
+        if type == 'shuffle':
+            return cls.SHUFFLE
+
+        raise ValueError('Invalid mutate name')

--- a/ea_server/engine/mut.py
+++ b/ea_server/engine/mut.py
@@ -1,16 +1,44 @@
+from enum import Enum
+from click import MissingParameter
 from deap import tools
 
 
-class Mutates():
-    SHUFFLE = tools.mutShuffleIndexes
+class MutatesTypes(Enum):
+    SHUFFLE = 'shuffle'
+
+
+class Mutate():
+
+    FUNCTIONS = {
+        MutatesTypes.SHUFFLE: tools.mutShuffleIndexes
+    }
+
+    KWARGS = {
+        MutatesTypes.SHUFFLE: ['indpb']
+    }
 
     @classmethod
-    def get_default(cls):
-        return cls.SHUFFLE, {"indpb": 0.05}
+    def default(cls):
+        return cls.FUNCTIONS[MutatesTypes.SHUFFLE], {"indpb": 0.05}
 
     @classmethod
     def get(cls, type: str):
-        if type == 'shuffle':
-            return cls.SHUFFLE
+        return cls.FUNCTIONS[MutatesTypes(type)]
 
-        raise ValueError('Invalid mutate name')
+    @classmethod
+    def get_kwargs(cls, type: str):
+        return cls.KWARGS[MutatesTypes(type)]
+
+    @classmethod
+    def get_types(cls):
+        return [e.value for e in MutatesTypes]
+
+    @classmethod
+    def validate(cls, type: str, **kwargs):
+        if keys := cls.get_kwargs(type):
+            missing = [key for key in keys if key not in kwargs]
+            if len(missing) > 0:
+                raise MissingParameter(
+                    f'Missing keys {missing} for {type} (in {cls.__name__})')
+
+        return True

--- a/ea_server/engine/sel.py
+++ b/ea_server/engine/sel.py
@@ -1,8 +1,16 @@
 from deap import tools
 
+
 class Selection():
     TOURNAMENT = tools.selTournament
 
     @classmethod
     def get_default(cls):
         return cls.TOURNAMENT, {"tournsize": 3}
+
+    @classmethod
+    def get(cls, type: str):
+        if type == 'tournament':
+            return cls.TOURNAMENT
+
+        raise ValueError('Invalid selection name')

--- a/ea_server/engine/sel.py
+++ b/ea_server/engine/sel.py
@@ -1,16 +1,43 @@
+from enum import Enum
+from click import MissingParameter
 from deap import tools
 
 
+class SelectionTypes(Enum):
+    TOURNAMENT = 'tournament'
+
+
 class Selection():
-    TOURNAMENT = tools.selTournament
+    FUNCTIONS = {
+        SelectionTypes.TOURNAMENT: tools.selTournament
+    }
+
+    KWARGS = {
+        SelectionTypes.TOURNAMENT: ['tournsize']
+    }
 
     @classmethod
-    def get_default(cls):
-        return cls.TOURNAMENT, {"tournsize": 3}
+    def default(cls):
+        return cls.FUNCTIONS[SelectionTypes.TOURNAMENT], {"tournsize": 3}
 
     @classmethod
     def get(cls, type: str):
-        if type == 'tournament':
-            return cls.TOURNAMENT
+        return cls.FUNCTIONS[SelectionTypes(type)]
 
-        raise ValueError('Invalid selection name')
+    @classmethod
+    def get_kwargs(cls, type: str):
+        return cls.KWARGS[SelectionTypes(type)]
+
+    @classmethod
+    def get_types(cls):
+        return [e.value for e in SelectionTypes]
+
+    @classmethod
+    def validate(cls, type: str, **kwargs):
+        if keys := cls.get_kwargs(type):
+            missing = [key for key in keys if key not in kwargs]
+            if len(missing) > 0:
+                raise MissingParameter(
+                    f'Missing keys {missing} for {type} (in {cls.__name__})')
+        
+        return True


### PR DESCRIPTION
Add support for model configuration via API with query params.
We still need to think about `mutate` and `selection` args (maybe with body params?)

Fix: #21 